### PR TITLE
防止取标题时出现过多的字而出现的bug

### DIFF
--- a/dist/modules/chat/chat.service.js
+++ b/dist/modules/chat/chat.service.js
@@ -251,6 +251,8 @@ let ChatService = class ChatService {
                 else {
                     chatTitle = '创意 AI';
                 }
+                //防止回答超过很多个字，在这里预防一下
+                chatTitle = chatTitle.length > 20 ? chatTitle.slice(0, 20) : chatTitle;
                 await this.chatGroupService.update({
                     groupId,
                     title: chatTitle,


### PR DESCRIPTION
### 修复了一个会因为取标题时，ai对取标题的回复过长而产生的bug
#### bug描述
bug产生是用户第一次提问，如“要求写一段基于springboot新能源汽车在线租赁系统的总结与展望，写一段连续的内容1000字，不要分点”，这里的出现的要求1000字，有概率导致取标题时要求的10个字ai对其忽略了，于是输出了过多
导致超出数据库存的标题长度，而导致程序重启而出问题
#### 解决
在存标题前进行判断截取（这里是稍微比10个字截取长一点）
`chatTitle = chatTitle.length > 20 ? chatTitle.slice(0, 20) : chatTitle;`
